### PR TITLE
Add support for opening egui links in browser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,15 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["opengl"]
+default = ["opengl", "links"]
 opengl = ["egui_glow", "baseview/opengl"]
+links = ["webbrowser"]
 
 [dependencies]
 egui = "0.19"
 egui_glow = { version = "0.19", optional = true }
 keyboard-types = { version = "0.6.1", default-features = false }
-baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "eae4033e7d2cc9c31ccaa2794d5d08eedf2f510c" }
+baseview = { git = "https://github.com/helgoboss/baseview.git", branch = "try-borrow-mut" }
 raw-window-handle = "0.4.2"
 copypasta = "0.8"
+webbrowser = { version = "0.8", optional = true }

--- a/src/window.rs
+++ b/src/window.rs
@@ -327,6 +327,9 @@ where
                 self.repaint_after = Some(repaint_after);
             }
 
+            if let Some(open_url) = platform_output.open_url {
+                open_url_in_browser(&open_url.url);
+            }
             if !platform_output.copied_text.is_empty() {
                 if let Some(clipboard_ctx) = &mut self.clipboard_ctx {
                     if let Err(err) = clipboard_ctx.set_contents(platform_output.copied_text) {
@@ -625,4 +628,9 @@ fn is_paste_command(modifiers: egui::Modifiers, keycode: keyboard_types::Code) -
         || (cfg!(target_os = "windows")
             && modifiers.shift
             && keycode == keyboard_types::Code::Insert)
+}
+
+fn open_url_in_browser(_url: &str) {
+    #[cfg(feature = "webbrowser")]
+    let _ = webbrowser::open(_url);
 }


### PR DESCRIPTION
Here's a minimal implementation that simply follows the example of egui-winit.

However, this shouldn't be merged yet because it requires a [change in the baseview crate](https://github.com/RustAudio/baseview/pull/130). Without that, a BorrowMut panic occurs because opening the webbrowser shortly **re**enters the window procecure.