### PR TITLE
bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ default_fonts = ["egui/default_fonts"]
 rayon = ["egui/rayon"]
 
 [dependencies]
-egui = { version = "0.26", default-features = false, features = ["bytemuck"] }
-egui_glow = { version = "0.26", optional = true }
+egui = { version = "0.27", default-features = false, features = ["bytemuck"] }
+egui_glow = { version = "0.27", optional = true }
 keyboard-types = { version = "0.6", default-features = false }
-baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "2c1b1a7b0fef1a29a5150a6a8f6fef6a0cbab8c4" }
+baseview = { git = "https://github.com/RustAudio/baseview.git", rev = "45465c5f46abed6c6ce370fffde5edc8e4cd5aa3" }
 raw-window-handle = "0.5"
 # TODO: Enable wayland feature when baseview gets wayland support.
 copypasta = { version = "0.10", default-features = false, features = ["x11"] }


### PR DESCRIPTION
bumped egui to 0.27 and baseview to the latest commit. tested with the simple_demo example and everything seems to be working