### PR TITLE
fix: return EventStatus::Ignored for unhandled events

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -656,7 +656,25 @@ where
             },
         }
 
-        return_status
+// For keyboard events, also check if egui actually wants keyboard input
+        // This allows DAW shortcuts (spacebar, etc.) to pass through when no text field is focused
+        match &event {
+            baseview::Event::Keyboard(_) => {
+                if return_status == EventStatus::Captured && !self.egui_ctx.wants_keyboard_input() {
+                    EventStatus::Ignored
+                } else {
+                    return_status
+                }
+            }
+            baseview::Event::Mouse(_) => {
+                if self.egui_ctx.is_using_pointer() || self.egui_ctx.wants_pointer_input() {
+                    EventStatus::Captured
+                } else {
+                    EventStatus::Ignored
+                }
+            }
+            baseview::Event::Window(_) => EventStatus::Captured,
+        }
     }
 }
 


### PR DESCRIPTION
Previously `on_event` unconditionally returned `EventStatus::Captured`, preventing keyboard shortcuts from reaching the DAW host when using egui-baseview in audio plugins.

This checks `wants_keyboard_input()` and `is_using_pointer()`/`wants_pointer_input()` to determine whether egui actually needs the event. vizia-baseview takes the opposite approach (always returns `Ignored`), which works but means vizia never claims events. This PR is more precise—capturing only when egui needs input.

This is complementary to `KeyCapture`: `KeyCapture` provides manual opt-in/opt-out per key, while this PR provides automatic context-aware defaults. With both, plugins work correctly out of the box while still allowing manual override.

Tested in Bitwig with a nih-plug CLAP plugin.