### PR TITLE
Smooth resizing fix for egui-baseview requiring baseview's PR https://github.com/RustAudio/baseview/pull/211 to be merged

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ mod renderer;
 mod translate;
 mod window;
 
-pub use window::{EguiWindow, KeyCapture, Queue};
+pub use window::{screen_cursor_pos, EguiWindow, KeyCapture, Queue};
 
 pub use egui;
 pub use renderer::GraphicsConfig;


### PR DESCRIPTION
This solves problem with resizing drag on nih-plug with egui, when the mouse during resizing drag sometimes slips out of the window and interrupts resizing.

It requires requiring baseview's PR https://github.com/RustAudio/baseview/pull/211 to be merged

Tested with nih-plug and egui together on macOS.